### PR TITLE
Resolve more request changes and warnings

### DIFF
--- a/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
+++ b/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
@@ -38,7 +38,9 @@ public class RemoveLinksToNotExistentFiles implements CleanupJob {
         for (LinkedFile file : files) {
             LinkedFileHandler fileHandler = new LinkedFileHandler(file, entry, databaseContext, filePreferences);
 
-            if (!file.isOnlineLink()) {
+            if (file.isOnlineLink()) {
+                cleanedUpFiles.add(file);
+            } else {
                 Optional<Path> oldFile = file.findIn(databaseContext, filePreferences);
 
                 if (oldFile.isEmpty()) {
@@ -46,8 +48,6 @@ public class RemoveLinksToNotExistentFiles implements CleanupJob {
                 } else {
                     cleanedUpFiles.add(file);
                 }
-            } else {
-                cleanedUpFiles.add(file);
             }
         }
 

--- a/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
+++ b/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.jabref.logic.externalfiles.LinkedFileHandler;
 import org.jabref.model.FieldChange;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -15,13 +14,7 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.util.OptionalUtil;
 import org.jabref.preferences.FilePreferences;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class RemoveLinksToNotExistentFiles implements CleanupJob {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveLinksToNotExistentFiles.class);
-
     private final BibDatabaseContext databaseContext;
     private final FilePreferences filePreferences;
 
@@ -36,8 +29,6 @@ public class RemoveLinksToNotExistentFiles implements CleanupJob {
         List<LinkedFile> cleanedUpFiles = new ArrayList<>();
         boolean changed = false;
         for (LinkedFile file : files) {
-            LinkedFileHandler fileHandler = new LinkedFileHandler(file, entry, databaseContext, filePreferences);
-
             if (file.isOnlineLink()) {
                 cleanedUpFiles.add(file);
             } else {

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -59,7 +59,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
                 .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(List.of(
-                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF"),
+                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"),
                     fileField)))
                 .withField(StandardField.ISSUE, "4")
                 .withField(StandardField.ISSN, "1941-0050")
@@ -80,9 +80,9 @@ public class RemoveLinksToNotExistentFilesTest {
         LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
         FieldChange expectedChange = new FieldChange(entry, StandardField.FILE,
             FileFieldWriter.getStringRepresentation(List.of(
-            new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF"),
+            new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"),
             fileField)),
-            FileFieldWriter.getStringRepresentation(new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF"))
+            FileFieldWriter.getStringRepresentation(new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"))
         );
         BibEntry expectedEntry = new BibEntry(StandardEntryType.Article)
                 .withField(StandardField.AUTHOR, "Shatakshi Sharma and Bhim Singh and Sukumar Mishra")
@@ -90,7 +90,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
                 .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(
-                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF")))
+                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF")))
                 .withField(StandardField.ISSUE, "4")
                 .withField(StandardField.ISSN, "1941-0050")
                 .withField(StandardField.JOURNALTITLE, "IEEE Transactions on Industrial Informatics")
@@ -116,7 +116,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
                 .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(List.of(
-                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF"),
+                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"),
                     fileField)))
                 .withField(StandardField.ISSUE, "4")
                 .withField(StandardField.ISSN, "1941-0050")

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -141,7 +141,9 @@ public class RemoveLinksToNotExistentFilesTest {
     @Test
     void deleteLinkedFile() {
         LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
-        entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField)); // There is only one linked file in entry
+
+        // There is only one linked file in entry
+        entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
         FieldChange expectedChange = new FieldChange(entry, StandardField.FILE,
             FileFieldWriter.getStringRepresentation(fileField),
             null);

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -101,7 +101,11 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.VOLUME, "16")
                 .withField(StandardField.KEYWORDS, "Batteries, Generators, Economics, Power quality, State of charge, Harmonic analysis, Control systems, Battery, diesel generator (DG), distributed generation, power quality, photovoltaic (PV), voltage source converter (VSC)");
 
-        fileBefore.toFile().delete();
+        try {
+            Files.delete(fileBefore);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         List<FieldChange> changes = removeLinks.cleanup(entry);
 
         assertEquals(expectedChange, changes.getFirst());
@@ -155,7 +159,11 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.VOLUME, "16")
                 .withField(StandardField.KEYWORDS, "Batteries, Generators, Economics, Power quality, State of charge, Harmonic analysis, Control systems, Battery, diesel generator (DG), distributed generation, power quality, photovoltaic (PV), voltage source converter (VSC)");
 
-        fileBefore.toFile().delete();
+        try {
+            Files.delete(fileBefore);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         List<FieldChange> changes = removeLinks.cleanup(entry);
 
         assertEquals(expectedChange, changes.getFirst());

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -60,7 +60,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
                 .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(List.of(
-                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", ""),
+                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF"),
                     fileField)))
                 .withField(StandardField.ISSUE, "4")
                 .withField(StandardField.ISSN, "1941-0050")
@@ -81,9 +81,9 @@ public class RemoveLinksToNotExistentFilesTest {
         LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
         FieldChange expectedChange = new FieldChange(entry, StandardField.FILE,
             FileFieldWriter.getStringRepresentation(List.of(
-            new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", ""),
+            new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF"),
             fileField)),
-            FileFieldWriter.getStringRepresentation(new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", ""))
+            FileFieldWriter.getStringRepresentation(new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF"))
         );
         BibEntry expectedEntry = new BibEntry(StandardEntryType.Article)
                 .withField(StandardField.AUTHOR, "Shatakshi Sharma and Bhim Singh and Sukumar Mishra")
@@ -91,7 +91,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
                 .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(
-                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "")))
+                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF")))
                 .withField(StandardField.ISSUE, "4")
                 .withField(StandardField.ISSN, "1941-0050")
                 .withField(StandardField.JOURNALTITLE, "IEEE Transactions on Industrial Informatics")
@@ -121,7 +121,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
                 .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(List.of(
-                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", ""),
+                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "PDF"),
                     fileField)))
                 .withField(StandardField.ISSUE, "4")
                 .withField(StandardField.ISSN, "1941-0050")

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class RemoveLinksToNotExistentFilesTest {
-    private Path defaultFileFolder;
+    private Path newFileFolder;
     private Path fileBefore;
     private BibEntry entry;
     private FilePreferences filePreferences;
@@ -37,8 +37,8 @@ public class RemoveLinksToNotExistentFilesTest {
     @BeforeEach
     void setUp(@TempDir Path bibFolder) throws IOException {
         // The folder where the files should be moved to
-        defaultFileFolder = bibFolder.resolve("pdf");
-        Files.createDirectory(defaultFileFolder);
+        newFileFolder = bibFolder.resolve("pdf");
+        Files.createDirectory(newFileFolder);
 
         Path originalFileFolder = bibFolder.resolve("files");
         Path testBibFolder = bibFolder.resolve("test.bib");
@@ -47,7 +47,7 @@ public class RemoveLinksToNotExistentFilesTest {
         Files.createFile(fileBefore);
 
         MetaData metaData = new MetaData();
-        metaData.setDefaultFileDirectory(defaultFileFolder.toAbsolutePath().toString());
+        metaData.setDefaultFileDirectory(newFileFolder.toAbsolutePath().toString());
         databaseContext = new BibDatabaseContext(new BibDatabase(), metaData);
         Files.createFile(testBibFolder);
         databaseContext.setDatabasePath(testBibFolder);

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -77,7 +77,7 @@ public class RemoveLinksToNotExistentFilesTest {
     }
 
     @Test
-    void deleteFileInEntryWithMultipleFileLinks() {
+    void deleteFileInEntryWithMultipleFileLinks() throws IOException {
         LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
         FieldChange expectedChange = new FieldChange(entry, StandardField.FILE,
             FileFieldWriter.getStringRepresentation(List.of(
@@ -101,11 +101,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.VOLUME, "16")
                 .withField(StandardField.KEYWORDS, "Batteries, Generators, Economics, Power quality, State of charge, Harmonic analysis, Control systems, Battery, diesel generator (DG), distributed generation, power quality, photovoltaic (PV), voltage source converter (VSC)");
 
-        try {
-            Files.delete(fileBefore);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        Files.delete(fileBefore);
         List<FieldChange> changes = removeLinks.cleanup(entry);
 
         assertEquals(expectedChange, changes.getFirst());
@@ -139,7 +135,7 @@ public class RemoveLinksToNotExistentFilesTest {
     }
 
     @Test
-    void deleteLinkedFile() {
+    void deleteLinkedFile() throws IOException {
         LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
 
         // There is only one linked file in entry
@@ -161,11 +157,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.VOLUME, "16")
                 .withField(StandardField.KEYWORDS, "Batteries, Generators, Economics, Power quality, State of charge, Harmonic analysis, Control systems, Battery, diesel generator (DG), distributed generation, power quality, photovoltaic (PV), voltage source converter (VSC)");
 
-        try {
-            Files.delete(fileBefore);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        Files.delete(fileBefore);
         List<FieldChange> changes = removeLinks.cleanup(entry);
 
         assertEquals(expectedChange, changes.getFirst());

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -77,7 +77,7 @@ public class RemoveLinksToNotExistentFilesTest {
     }
 
     @Test
-    void deleteFileInMultipleLinkedEntry() {
+    void deleteFileInEntryWithMultipleFileLinks() {
         LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
         FieldChange expectedChange = new FieldChange(entry, StandardField.FILE,
             FileFieldWriter.getStringRepresentation(List.of(

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -40,11 +40,10 @@ public class RemoveLinksToNotExistentFilesTest {
         defaultFileFolder = bibFolder.resolve("pdf");
         Files.createDirectory(defaultFileFolder);
 
-        // The folder where the files are located originally
-        Path fileFolder = bibFolder.resolve("files");
+        Path originalFileFolder = bibFolder.resolve("files");
         Path testBibFolder = bibFolder.resolve("test.bib");
-        Files.createDirectory(fileFolder);
-        fileBefore = fileFolder.resolve("test.pdf");
+        Files.createDirectory(originalFileFolder);
+        fileBefore = originalFileFolder.resolve("test.pdf");
         Files.createFile(fileBefore);
 
         MetaData metaData = new MetaData();

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -42,6 +42,7 @@ public class RemoveLinksToNotExistentFilesTest {
 
         // The folder where the files are located originally
         Path fileFolder = bibFolder.resolve("files");
+        Path testBibFolder = bibFolder.resolve("test.bib");
         Files.createDirectory(fileFolder);
         fileBefore = fileFolder.resolve("test.pdf");
         Files.createFile(fileBefore);
@@ -49,8 +50,8 @@ public class RemoveLinksToNotExistentFilesTest {
         MetaData metaData = new MetaData();
         metaData.setDefaultFileDirectory(defaultFileFolder.toAbsolutePath().toString());
         databaseContext = new BibDatabaseContext(new BibDatabase(), metaData);
-        Files.createFile(bibFolder.resolve("test.bib"));
-        databaseContext.setDatabasePath(bibFolder.resolve("test.bib"));
+        Files.createFile(testBibFolder);
+        databaseContext.setDatabasePath(testBibFolder);
 
         LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
 

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -3,7 +3,6 @@ package org.jabref.logic.cleanup;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.jabref.logic.bibtex.FileFieldWriter;
@@ -60,7 +59,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.DATE, "April 2020")
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
-                .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(Arrays.asList(
+                .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(List.of(
                     new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", ""),
                     fileField)))
                 .withField(StandardField.ISSUE, "4")
@@ -81,7 +80,7 @@ public class RemoveLinksToNotExistentFilesTest {
     void deleteFileInMultipleLinkedEntry() {
         LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
         FieldChange expectedChange = new FieldChange(entry, StandardField.FILE,
-            FileFieldWriter.getStringRepresentation(Arrays.asList(
+            FileFieldWriter.getStringRepresentation(List.of(
             new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", ""),
             fileField)),
             FileFieldWriter.getStringRepresentation(new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", ""))
@@ -117,7 +116,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.DATE, "April 2020")
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
-                .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(Arrays.asList(
+                .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(List.of(
                     new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", ""),
                     fileField)))
                 .withField(StandardField.ISSUE, "4")

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -87,20 +87,20 @@ public class RemoveLinksToNotExistentFilesTest {
             FileFieldWriter.getStringRepresentation(new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", ""))
         );
         BibEntry expectedEntry = new BibEntry(StandardEntryType.Article)
-        .withField(StandardField.AUTHOR, "Shatakshi Sharma and Bhim Singh and Sukumar Mishra")
-        .withField(StandardField.DATE, "April 2020")
-        .withField(StandardField.YEAR, "2020")
-        .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
-        .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(
-            new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "")))
-        .withField(StandardField.ISSUE, "4")
-        .withField(StandardField.ISSN, "1941-0050")
-        .withField(StandardField.JOURNALTITLE, "IEEE Transactions on Industrial Informatics")
-        .withField(StandardField.PAGES, "2346--2356")
-        .withField(StandardField.PUBLISHER, "IEEE")
-        .withField(StandardField.TITLE, "Economic Operation and Quality Control in PV-BES-DG-Based Autonomous System")
-        .withField(StandardField.VOLUME, "16")
-        .withField(StandardField.KEYWORDS, "Batteries, Generators, Economics, Power quality, State of charge, Harmonic analysis, Control systems, Battery, diesel generator (DG), distributed generation, power quality, photovoltaic (PV), voltage source converter (VSC)");
+                .withField(StandardField.AUTHOR, "Shatakshi Sharma and Bhim Singh and Sukumar Mishra")
+                .withField(StandardField.DATE, "April 2020")
+                .withField(StandardField.YEAR, "2020")
+                .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
+                .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(
+                    new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF", "")))
+                .withField(StandardField.ISSUE, "4")
+                .withField(StandardField.ISSN, "1941-0050")
+                .withField(StandardField.JOURNALTITLE, "IEEE Transactions on Industrial Informatics")
+                .withField(StandardField.PAGES, "2346--2356")
+                .withField(StandardField.PUBLISHER, "IEEE")
+                .withField(StandardField.TITLE, "Economic Operation and Quality Control in PV-BES-DG-Based Autonomous System")
+                .withField(StandardField.VOLUME, "16")
+                .withField(StandardField.KEYWORDS, "Batteries, Generators, Economics, Power quality, State of charge, Harmonic analysis, Control systems, Battery, diesel generator (DG), distributed generation, power quality, photovoltaic (PV), voltage source converter (VSC)");
 
         fileBefore.toFile().delete();
         List<FieldChange> changes = removeLinks.cleanup(entry);

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -25,17 +25,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class RemoveLinksToNotExistentFilesTest {
-    private Path newFileFolder;
     private Path fileBefore;
     private BibEntry entry;
-    private FilePreferences filePreferences;
-    private BibDatabaseContext databaseContext;
     private RemoveLinksToNotExistentFiles removeLinks;
 
     @BeforeEach
     void setUp(@TempDir Path bibFolder) throws IOException {
         // The folder where the files should be moved to
-        newFileFolder = bibFolder.resolve("pdf");
+        Path newFileFolder = bibFolder.resolve("pdf");
         Files.createDirectory(newFileFolder);
 
         Path originalFileFolder = bibFolder.resolve("files");
@@ -46,7 +43,8 @@ public class RemoveLinksToNotExistentFilesTest {
 
         MetaData metaData = new MetaData();
         metaData.setDefaultFileDirectory(newFileFolder.toAbsolutePath().toString());
-        databaseContext = new BibDatabaseContext(new BibDatabase(), metaData);
+
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(), metaData);
         Files.createFile(testBibFolder);
         databaseContext.setDatabasePath(testBibFolder);
 
@@ -70,7 +68,7 @@ public class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.VOLUME, "16")
                 .withField(StandardField.KEYWORDS, "Batteries, Generators, Economics, Power quality, State of charge, Harmonic analysis, Control systems, Battery, diesel generator (DG), distributed generation, power quality, photovoltaic (PV), voltage source converter (VSC)");
 
-        filePreferences = mock(FilePreferences.class);
+        FilePreferences filePreferences = mock(FilePreferences.class);
         when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
         removeLinks = new RemoveLinksToNotExistentFiles(databaseContext, filePreferences);
     }

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -104,7 +103,7 @@ public class RemoveLinksToNotExistentFilesTest {
         Files.delete(fileBefore);
         List<FieldChange> changes = removeLinks.cleanup(entry);
 
-        assertEquals(expectedChange, changes.getFirst());
+        assertEquals(List.of(expectedChange), changes);
         assertEquals(expectedEntry, entry);
     }
 
@@ -130,7 +129,7 @@ public class RemoveLinksToNotExistentFilesTest {
 
         List<FieldChange> changes = removeLinks.cleanup(entry);
 
-        assertTrue(changes.isEmpty());
+        assertEquals(List.of(), changes);
         assertEquals(expectedEntry, entry);
     }
 
@@ -160,7 +159,7 @@ public class RemoveLinksToNotExistentFilesTest {
         Files.delete(fileBefore);
         List<FieldChange> changes = removeLinks.cleanup(entry);
 
-        assertEquals(expectedChange, changes.getFirst());
+        assertEquals(List.of(expectedChange), changes);
         assertEquals(expectedEntry, entry);
     }
 }


### PR DESCRIPTION

Requested Changes:
- Reverse if else condition in RemoveLinksToNotExistentFiles#cleanup
- Store bibFolder.resolve("test.bib") in variable in RemoveLinksToNotExistentFilesTest#setup
- Rename variable `fileFolder` to `originalFileFolder` in RemoveLinksToNotExistentFilesTest#setup
- Remove comment in RemoveLinksToNotExistentFilesTest#setup
- Rename variable `Path defaultFileFolder` to `Path newFileFolder` in RemoveLinksToNotExistentFilesTest#setup
- Indent `.withField` statements in RemoveLinksToNotExistentFilesTest#deleteFileInEntryWithMultipleFileLinks
- Changed `LinkedFile` constructor calls to use third parameter in RemoveLinksToNotExistentFilesTest
- Replaced `Arrays.asList()` with `List.of()` in RemoveLinksToNotExistentFilesTest
- Assert full lists instead of elements in RemoveLinksToNotExistentFilesTest
- Use `java.nio` for file deletion in RemoveLinksToNotExistentFilesTest
- Formatting comments correctly in RemoveLinksToNotExistentFilesTest#deleteLinkedFile
- Change test name `deleteFileInMultipleLinkedEntry` to `deleteFileInEntryWithMultipleFileLinks`

Other Changes: 
- Changed class fields `Path newFileFolder` `FilePreferences filePreferences` and ` BibDatabaseContext databaseContext` into local variables in RemoveLinksToNotExistentFilesTest
- Removed unused variables `LOGGER` and `fileHandler` in RemoveLinksToNotExistentFiles

