### PR TITLE
Resolve requested "nitpicks" and warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added the possibility to redownload files that had been present but are no longer in the specified location. [#10848](https://github.com/JabRef/jabref/issues/10848)
 - We added the citation key pattern `[camelN]`. Equivalent to the first N words of the `[camel]` pattern.
 - We added ability to export in CFF (Citation File Format) [#10661](https://github.com/JabRef/jabref/issues/10661).
+- We added ability to push entries to TeXworks. [#3197](https://github.com/JabRef/jabref/issues/3197)
+- We added the ability to zoom in and out in the document viewer using <kbd>Ctrl</kbd> + <kbd>Scroll</kbd>. [#10964](https://github.com/JabRef/jabref/pull/10964)
 - We added a Cleanup for removing non-existent files and grouped the related options [#10929](https://github.com/JabRef/jabref/issues/10929)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added the possibility to redownload files that had been present but are no longer in the specified location. [#10848](https://github.com/JabRef/jabref/issues/10848)
 - We added the citation key pattern `[camelN]`. Equivalent to the first N words of the `[camel]` pattern.
 - We added ability to export in CFF (Citation File Format) [#10661](https://github.com/JabRef/jabref/issues/10661).
-- We added CleanupJob for removing non-existent files and added a checkbox for it in Cleanup entries, as well as grouped the checkboxes in Cleanup entries. [#10929] (<https://github.com/JabRef/jabref/issues/10929>)
+- We added a Cleanup for removing non-existent files and grouped the related options [#10929](https://github.com/JabRef/jabref/issues/10929)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added the possibility to redownload files that had been present but are no longer in the specified location. [#10848](https://github.com/JabRef/jabref/issues/10848)
 - We added the citation key pattern `[camelN]`. Equivalent to the first N words of the `[camel]` pattern.
 - We added ability to export in CFF (Citation File Format) [#10661](https://github.com/JabRef/jabref/issues/10661).
+- We added CleanupJob for removing non-existent files and added a checkbox for it in Cleanup entries, as well as grouped the checkboxes in Cleanup entries. [#10929] (https://github.com/JabRef/jabref/issues/10929)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added the possibility to redownload files that had been present but are no longer in the specified location. [#10848](https://github.com/JabRef/jabref/issues/10848)
 - We added the citation key pattern `[camelN]`. Equivalent to the first N words of the `[camel]` pattern.
 - We added ability to export in CFF (Citation File Format) [#10661](https://github.com/JabRef/jabref/issues/10661).
-- We added CleanupJob for removing non-existent files and added a checkbox for it in Cleanup entries, as well as grouped the checkboxes in Cleanup entries. [#10929] (https://github.com/JabRef/jabref/issues/10929)
+- We added CleanupJob for removing non-existent files and added a checkbox for it in Cleanup entries, as well as grouped the checkboxes in Cleanup entries. [#10929] (<https://github.com/JabRef/jabref/issues/10929>)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.fxml
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.fxml
@@ -14,26 +14,39 @@
         <ToggleGroup fx:id="timestampCleanup"/>
       </fx:define>
 
-    
-      <CheckBox fx:id="cleanUpDOI" text="%Move DOIs from note and URL field to DOI field and remove http prefix" />
-      <CheckBox fx:id="cleanUpEprint" text="%Move preprint information from 'URL' and 'journal' field to the 'eprint' field" />
-      <CheckBox fx:id="cleanUpURL" text="%Move URL in note field to url field" />
-      <CheckBox fx:id="cleanUpISSN" text="%Reformat ISSN" />
-      <CheckBox fx:id="cleanUpUpgradeExternalLinks" />
-      <CheckBox fx:id="cleanUpMovePDF" />
-      <CheckBox fx:id="cleanUpMakePathsRelative" text="%Make paths of linked files relative (if possible)" />
-      <CheckBox fx:id="cleanUpRenamePDF" text="%Rename PDFs to given filename format pattern" />
-      <VBox prefHeight="40.0" prefWidth="451.0" spacing="10.0">
-          <Label fx:id="cleanupRenamePDFLabel" />
-          <CheckBox fx:id="cleanUpRenamePDFonlyRelativePaths" text="%Rename only PDFs having a relative path" />
-       <VBox.margin>
-          <Insets left="20.0" />
-       </VBox.margin>
+      <Label text="Miscellanous" />
+      <VBox>
+         <VBox.margin>
+            <Insets left="20.0" />
+         </VBox.margin>
+         <CheckBox fx:id="cleanUpDOI" text="%Move DOIs from note and URL field to DOI field and remove http prefix" />
+         <CheckBox fx:id="cleanUpEprint" text="%Move preprint information from 'URL' and 'journal' field to the 'eprint' field" />
+         <CheckBox fx:id="cleanUpURL" text="%Move URL in note field to url field" />
+         <CheckBox fx:id="cleanUpISSN" text="%Reformat ISSN" />
+         <CheckBox fx:id="cleanUpBiblatex" text="%Convert to biblatex format (e.g., store publication date in date field)" />
+         <CheckBox fx:id="cleanUpBibtex" text="%Convert to BibTeX format (e.g., store publication date in year and month fields)" />
+         <CheckBox fx:id="cleanUpTimestampToCreationDate" text="%Convert timestamp field to field 'creationdate'" />
+         <CheckBox fx:id="cleanUpTimestampToModificationDate" text="%Convert timestamp field to field 'modificationdate'" />
       </VBox>
-      <CheckBox fx:id="cleanUpBiblatex" text="%Convert to biblatex format (e.g., store publication date in date field)" />
-      <CheckBox fx:id="cleanUpBibtex" text="%Convert to BibTeX format (e.g., store publication date in year and month fields)" />
-      <CheckBox fx:id="cleanUpTimestampToCreationDate" text="%Convert timestamp field to field 'creationdate'" />
-      <CheckBox fx:id="cleanUpTimestampToModificationDate" text="%Convert timestamp field to field 'modificationdate'" />
+
+      <Label text="File Related" />
+      <VBox>
+         <VBox.margin>
+            <Insets left="20.0" />
+         </VBox.margin>
+         <CheckBox fx:id="cleanUpUpgradeExternalLinks" />
+         <CheckBox fx:id="cleanUpMovePDF" />
+         <CheckBox fx:id="cleanUpMakePathsRelative" text="%Make paths of linked files relative (if possible)" />
+         <CheckBox fx:id="cleanUpRenamePDF" text="%Rename PDFs to given filename format pattern" />
+         <VBox prefHeight="40.0" prefWidth="451.0" spacing="10.0">
+            <Label fx:id="cleanupRenamePDFLabel" />
+            <CheckBox fx:id="cleanUpRenamePDFonlyRelativePaths" text="%Rename only PDFs having a relative path" />
+         <VBox.margin>
+            <Insets left="20.0" />
+         </VBox.margin>
+         </VBox>
+         <CheckBox fx:id="cleanUpDeletedFiles" text="%Remove links to non existent files" />
+      </VBox>
             <FieldFormatterCleanupsPanel fx:id="formatterCleanupsPanel" />
  <padding>
     <Insets bottom="10.0" left="15.0" right="10.0" top="10.0" />

--- a/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.fxml
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.fxml
@@ -45,7 +45,7 @@
             <Insets left="20.0" />
          </VBox.margin>
          </VBox>
-         <CheckBox fx:id="cleanUpDeletedFiles" text="%Remove links to non existent files" />
+         <CheckBox fx:id="cleanUpDeletedFiles" text="Remove links to non existent files" />
       </VBox>
             <FieldFormatterCleanupsPanel fx:id="formatterCleanupsPanel" />
  <padding>

--- a/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -73,7 +73,6 @@ public class CleanupPresetPanel extends VBox {
                                             .concat(filePreferences.getFileNamePattern());
         cleanupRenamePDFLabel.setText(currentPattern);
 
-        
         cleanUpBibtex.selectedProperty().addListener(
                 (observable, oldValue, newValue) -> {
                     if (newValue) {

--- a/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -33,6 +33,7 @@ public class CleanupPresetPanel extends VBox {
     @FXML private CheckBox cleanUpMakePathsRelative;
     @FXML private CheckBox cleanUpRenamePDF;
     @FXML private CheckBox cleanUpRenamePDFonlyRelativePaths;
+    @FXML private CheckBox cleanUpDeletedFiles;
     @FXML private CheckBox cleanUpUpgradeExternalLinks;
     @FXML private CheckBox cleanUpBiblatex;
     @FXML private CheckBox cleanUpBibtex;
@@ -71,6 +72,8 @@ public class CleanupPresetPanel extends VBox {
                                             .concat(": ")
                                             .concat(filePreferences.getFileNamePattern());
         cleanupRenamePDFLabel.setText(currentPattern);
+
+        
         cleanUpBibtex.selectedProperty().addListener(
                 (observable, oldValue, newValue) -> {
                     if (newValue) {
@@ -109,6 +112,7 @@ public class CleanupPresetPanel extends VBox {
         cleanUpRenamePDF.setSelected(preset.isActive(CleanupPreferences.CleanupStep.RENAME_PDF));
         cleanUpRenamePDFonlyRelativePaths.setSelected(preset.isActive(CleanupPreferences.CleanupStep.RENAME_PDF_ONLY_RELATIVE_PATHS));
         cleanUpUpgradeExternalLinks.setSelected(preset.isActive(CleanupPreferences.CleanupStep.CLEAN_UP_UPGRADE_EXTERNAL_LINKS));
+        cleanUpDeletedFiles.setSelected(preset.isActive(CleanupPreferences.CleanupStep.CLEAN_UP_DELETED_LINKED_FILES));
         cleanUpBiblatex.setSelected(preset.isActive(CleanupPreferences.CleanupStep.CONVERT_TO_BIBLATEX));
         cleanUpBibtex.setSelected(preset.isActive(CleanupPreferences.CleanupStep.CONVERT_TO_BIBTEX));
         cleanUpTimestampToCreationDate.setSelected(preset.isActive(CleanupPreferences.CleanupStep.CONVERT_TIMESTAMP_TO_CREATIONDATE));
@@ -149,6 +153,9 @@ public class CleanupPresetPanel extends VBox {
         }
         if (cleanUpUpgradeExternalLinks.isSelected()) {
             activeJobs.add(CleanupPreferences.CleanupStep.CLEAN_UP_UPGRADE_EXTERNAL_LINKS);
+        }
+        if (cleanUpDeletedFiles.isSelected()) {
+            activeJobs.add(CleanupPreferences.CleanupStep.CLEAN_UP_DELETED_LINKED_FILES);
         }
         if (cleanUpBiblatex.isSelected()) {
             activeJobs.add(CleanupPreferences.CleanupStep.CONVERT_TO_BIBLATEX);

--- a/src/main/java/org/jabref/logic/cleanup/CleanupWorker.java
+++ b/src/main/java/org/jabref/logic/cleanup/CleanupWorker.java
@@ -67,6 +67,8 @@ public class CleanupWorker {
                     new RenamePdfCleanup(true, databaseContext, filePreferences);
             case CLEAN_UP_UPGRADE_EXTERNAL_LINKS ->
                     new UpgradePdfPsToFileCleanup();
+            case CLEAN_UP_DELETED_LINKED_FILES ->
+                    new RemoveLinksToNotExistentFiles(databaseContext, filePreferences);
             case CONVERT_TO_BIBLATEX ->
                     new ConvertToBiblatexCleanup();
             case CONVERT_TO_BIBTEX ->

--- a/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
+++ b/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.jabref.logic.externalfiles.LinkedFileHandler;
 import org.jabref.model.FieldChange;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -15,13 +14,7 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.util.OptionalUtil;
 import org.jabref.preferences.FilePreferences;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class RemoveLinksToNotExistentFiles implements CleanupJob {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveLinksToNotExistentFiles.class);
-
     private final BibDatabaseContext databaseContext;
     private final FilePreferences filePreferences;
 
@@ -36,9 +29,9 @@ public class RemoveLinksToNotExistentFiles implements CleanupJob {
         List<LinkedFile> cleanedUpFiles = new ArrayList<>();
         boolean changed = false;
         for (LinkedFile file : files) {
-            LinkedFileHandler fileHandler = new LinkedFileHandler(file, entry, databaseContext, filePreferences);
-
-            if (!file.isOnlineLink()) {
+            if (file.isOnlineLink()) {
+                cleanedUpFiles.add(file);
+            } else {
                 Optional<Path> oldFile = file.findIn(databaseContext, filePreferences);
 
                 if (oldFile.isEmpty()) {
@@ -46,8 +39,6 @@ public class RemoveLinksToNotExistentFiles implements CleanupJob {
                 } else {
                     cleanedUpFiles.add(file);
                 }
-            } else {
-                cleanedUpFiles.add(file);
             }
         }
 

--- a/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
+++ b/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
@@ -39,7 +39,6 @@ public class RemoveLinksToNotExistentFiles implements CleanupJob {
             LinkedFileHandler fileHandler = new LinkedFileHandler(file, entry, databaseContext, filePreferences);
             
             if (file.isOnlineLink() == false) {
-                
                 Optional<Path> oldFile = file.findIn(databaseContext, filePreferences);
                 
                 if (oldFile.isEmpty()) {

--- a/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
+++ b/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
@@ -1,0 +1,60 @@
+package org.jabref.logic.cleanup;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.jabref.logic.externalfiles.LinkedFileHandler;
+import org.jabref.model.FieldChange;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+import org.jabref.model.util.OptionalUtil;
+import org.jabref.preferences.FilePreferences;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RemoveLinksToNotExistentFiles implements CleanupJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveLinksToNotExistentFiles.class);
+
+    private final BibDatabaseContext databaseContext;
+    private final FilePreferences filePreferences;
+
+    public RemoveLinksToNotExistentFiles(BibDatabaseContext databaseContext, FilePreferences filePreferences) {
+        this.databaseContext = Objects.requireNonNull(databaseContext);
+        this.filePreferences = Objects.requireNonNull(filePreferences);
+    }
+
+    @Override
+    public List<FieldChange> cleanup(BibEntry entry) {
+        List<LinkedFile> files = entry.getFiles();
+        List<LinkedFile> files2 = new ArrayList<LinkedFile>();
+        boolean changed = false;
+        for (LinkedFile file : files) {
+            LinkedFileHandler fileHandler = new LinkedFileHandler(file, entry, databaseContext, filePreferences);
+            
+            if (file.isOnlineLink() == false) {
+                
+                Optional<Path> oldFile = file.findIn(databaseContext, filePreferences);
+                
+                if (oldFile.isEmpty()) {
+                    changed = true;
+                } else {
+                    files2.add(file);
+                }
+            }
+        }
+
+        if (changed) {
+            Optional<FieldChange> changes = entry.setFiles(files2);
+            return OptionalUtil.toList(changes);
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
+++ b/src/main/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFiles.java
@@ -33,24 +33,26 @@ public class RemoveLinksToNotExistentFiles implements CleanupJob {
     @Override
     public List<FieldChange> cleanup(BibEntry entry) {
         List<LinkedFile> files = entry.getFiles();
-        List<LinkedFile> files2 = new ArrayList<LinkedFile>();
+        List<LinkedFile> cleanedUpFiles = new ArrayList<>();
         boolean changed = false;
         for (LinkedFile file : files) {
             LinkedFileHandler fileHandler = new LinkedFileHandler(file, entry, databaseContext, filePreferences);
-            
-            if (file.isOnlineLink() == false) {
+
+            if (!file.isOnlineLink()) {
                 Optional<Path> oldFile = file.findIn(databaseContext, filePreferences);
-                
+
                 if (oldFile.isEmpty()) {
                     changed = true;
                 } else {
-                    files2.add(file);
+                    cleanedUpFiles.add(file);
                 }
+            } else {
+                cleanedUpFiles.add(file);
             }
         }
 
         if (changed) {
-            Optional<FieldChange> changes = entry.setFiles(files2);
+            Optional<FieldChange> changes = entry.setFiles(cleanedUpFiles);
             return OptionalUtil.toList(changes);
         }
 

--- a/src/main/java/org/jabref/preferences/CleanupPreferences.java
+++ b/src/main/java/org/jabref/preferences/CleanupPreferences.java
@@ -88,6 +88,7 @@ public class CleanupPreferences {
          * Collects file links from the pdf or ps field, and adds them to the list contained in the file field.
          */
         CLEAN_UP_UPGRADE_EXTERNAL_LINKS,
+        CLEAN_UP_DELETED_LINKED_FILES,
         /**
          * Converts to biblatex format
          */

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -105,7 +105,7 @@ public class RemoveLinksToNotExistentFilesTest {
         fileBefore.toFile().delete();
         List<FieldChange> changes = removeLinks.cleanup(entry);
 
-        assertEquals(expectedChange, changes.get(0));
+        assertEquals(expectedChange, changes.getFirst());
         assertEquals(expectedEntry, entry);
     }
 
@@ -159,7 +159,7 @@ public class RemoveLinksToNotExistentFilesTest {
         fileBefore.toFile().delete();
         List<FieldChange> changes = removeLinks.cleanup(entry);
 
-        assertEquals(expectedChange, changes.get(0));
+        assertEquals(expectedChange, changes.getFirst());
         assertEquals(expectedEntry, entry);
     }
 }

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -3,10 +3,7 @@ package org.jabref.logic.cleanup;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.jabref.logic.bibtex.FileFieldWriter;
 import org.jabref.model.FieldChange;
@@ -22,9 +19,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import org.jabref.logic.cleanup.RemoveLinksToNotExistentFiles;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -1,0 +1,83 @@
+package org.jabref.logic.cleanup;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.jabref.logic.bibtex.FileFieldWriter;
+import org.jabref.model.FieldChange;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.metadata.MetaData;
+import org.jabref.preferences.FilePreferences;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.jabref.logic.cleanup.RemoveLinksToNotExistentFiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RemoveLinksToNotExistentFilesTest {
+    private Path defaultFileFolder;
+    private Path fileBefore;
+    private BibEntry entry;
+    private FilePreferences filePreferences;
+    private BibDatabaseContext databaseContext;
+    private RemoveLinksToNotExistentFiles removeLinks;
+
+    @BeforeEach
+    void setUp(@TempDir Path bibFolder) throws IOException {
+        // The folder where the files should be moved to
+        defaultFileFolder = bibFolder.resolve("pdf");
+        Files.createDirectory(defaultFileFolder);
+
+        // The folder where the files are located originally
+        Path fileFolder = bibFolder.resolve("files");
+        Files.createDirectory(fileFolder);
+        fileBefore = fileFolder.resolve("test.pdf");
+        Files.createFile(fileBefore);
+
+        MetaData metaData = new MetaData();
+        metaData.setDefaultFileDirectory(defaultFileFolder.toAbsolutePath().toString());
+        databaseContext = new BibDatabaseContext(new BibDatabase(), metaData);
+        Files.createFile(bibFolder.resolve("test.bib"));
+        databaseContext.setDatabasePath(bibFolder.resolve("test.bib"));
+
+        entry = new BibEntry();
+        entry.setCitationKey("Toot");
+        entry.setField(StandardField.TITLE, "test title");
+        entry.setField(StandardField.YEAR, "1989");
+        LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
+        entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
+
+        filePreferences = mock(FilePreferences.class);
+        when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false); 
+        removeLinks = new RemoveLinksToNotExistentFiles(databaseContext, filePreferences);
+    }
+
+    @Test
+    void deleteLinkedFile() {
+        fileBefore.toFile().delete();
+        List<FieldChange> changes = removeLinks.cleanup(entry);
+        assertFalse(changes.isEmpty());
+    }
+
+    @Test
+    void keepLinksToExistingFiles() {
+        List<FieldChange> changes = removeLinks.cleanup(entry);
+        assertTrue(changes.isEmpty());
+    }
+}


### PR DESCRIPTION
Requested Changes:
- Reverse if else condition in RemoveLinksToNotExistentFiles#cleanup
- Store bibFolder.resolve("test.bib") in variable in RemoveLinksToNotExistentFilesTest#setup
- Rename variable `fileFolder` to `originalFileFolder` in RemoveLinksToNotExistentFilesTest#setup
- Remove comment in RemoveLinksToNotExistentFilesTest#setup
- Rename variable `Path defaultFileFolder` to `Path newFileFolder` in RemoveLinksToNotExistentFilesTest#setup
- Indent `.withField` statements in RemoveLinksToNotExistentFilesTest#deleteFileInEntryWithMultipleFileLinks
- Changed `LinkedFile` constructor calls to use third parameter in RemoveLinksToNotExistentFilesTest
- Replaced `Arrays.asList()` with `List.of()` in RemoveLinksToNotExistentFilesTest
- Assert full lists instead of elements in RemoveLinksToNotExistentFilesTest
- Use `java.nio` for file deletion in RemoveLinksToNotExistentFilesTest
- Formatting comments correctly in RemoveLinksToNotExistentFilesTest#deleteLinkedFile
- Change test name `deleteFileInMultipleLinkedEntry` to `deleteFileInEntryWithMultipleFileLinks`

Other Changes: 
- Changed class fields `Path newFileFolder` `FilePreferences filePreferences` and ` BibDatabaseContext databaseContext` into local variables in RemoveLinksToNotExistentFilesTest
- Removed unused variables `LOGGER` and `fileHandler` in RemoveLinksToNotExistentFiles
